### PR TITLE
Change the way buffers are allocated (Buffer.alloc() iso new Buffer()).

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ b[4] // 5
 
 ``` js
 // sometimes you get a variable length array that is terminated by a NULL byte.
-var buf = new Buffer(int.size * 3)
+var buf = Buffer.alloc(int.size * 3)
 int.set(buf, int.size * 0, 5)
 int.set(buf, int.size * 1, 8)
 int.set(buf, int.size * 2, 0) // <- terminate with 0s

--- a/lib/array.js
+++ b/lib/array.js
@@ -37,14 +37,14 @@ var Array_ = function Array (_type, _length) {
       // use the "fixedLength" if provided, otherwise throw an Error
       if (fixedLength > 0) {
         this.length = fixedLength
-        this.buffer = new Buffer(this.length * item_size)
+        this.buffer = Buffer.alloc(this.length * item_size)
       } else {
         throw new Error('A "length", "array" or "buffer" must be passed as the first argument')
       }
     } else if ('number' == typeof data) {
       // new IntArray(69)
       this.length = data
-      this.buffer = new Buffer(this.length * item_size)
+      this.buffer = Buffer.alloc(this.length * item_size)
     } else if (isArray(data)) {
       // new IntArray([ 1, 2, 3, 4, 5 ], {len})
       // use optional "length" if provided, otherwise use "fixedLength, otherwise
@@ -61,7 +61,7 @@ var Array_ = function Array (_type, _length) {
         throw new Error('array length must be at least ' + len + ', got ' + data.length)
       }
       this.length = len
-      this.buffer = new Buffer(len * item_size)
+      this.buffer = Buffer.alloc(len * item_size)
       for (var i = 0; i < len; i++) {
         this[i] = data[i]
       }

--- a/test/array.js
+++ b/test/array.js
@@ -16,7 +16,7 @@ describe('Array', function () {
     var CharArray = ArrayType('char')
 
     it('should map directly to a "string"', function () {
-      var b = Buffer.alloc('hello', 'ascii')
+      var b = Buffer.from('hello', 'ascii')
       var a = new CharArray(b)
       assert.equal(b.length, a.length)
       for (var i = 0; i < b.length; i++) {

--- a/test/array.js
+++ b/test/array.js
@@ -16,7 +16,7 @@ describe('Array', function () {
     var CharArray = ArrayType('char')
 
     it('should map directly to a "string"', function () {
-      var b = new Buffer('hello', 'ascii')
+      var b = Buffer.alloc('hello', 'ascii')
       var a = new CharArray(b)
       assert.equal(b.length, a.length)
       for (var i = 0; i < b.length; i++) {
@@ -127,7 +127,7 @@ describe('Array', function () {
       var IntArray = ArrayType(int)
 
       // manually create a NULL-terminated int[]
-      var buf = new Buffer(int.size * 3)
+      var buf = Buffer.alloc(int.size * 3)
       int.set(buf, int.size * 0, 5)
       int.set(buf, int.size * 1, 8)
       int.set(buf, int.size * 2, 0) // <- terminate with 0s


### PR DESCRIPTION
Please update the library, since the usage of new Buffer is deprecated.